### PR TITLE
add `arctic3d-blast` cli

### DIFF
--- a/src/arctic3d/cli_blast.py
+++ b/src/arctic3d/cli_blast.py
@@ -1,0 +1,81 @@
+"""Main CLI."""
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from arctic3d.modules.blast import run_blast
+from arctic3d.modules.sequence import to_fasta
+
+log = logging.getLogger("arctic3dlog")
+ch = logging.StreamHandler()
+formatter = logging.Formatter(
+    " [%(asctime)s %(module)s:L%(lineno)d %(levelname)s] %(message)s"
+)
+ch.setFormatter(formatter)
+log.addHandler(ch)
+
+
+argument_parser = argparse.ArgumentParser()
+argument_parser.add_argument("input_pdbs", nargs="+", default=[])
+
+argument_parser.add_argument(
+    "--db",
+    help="",
+)
+
+
+def load_args(arguments):
+    """
+    Load argument parser.
+
+    Parameters
+    ----------
+    arguments : argparse.ArgumentParser
+        Argument parser.
+
+    Returns
+    -------
+    cmd : argparse.Namespace
+        Parsed command-line arguments.
+
+    """
+    return arguments.parse_args()
+
+
+def cli(arguments, main_func):
+    """
+    Command-line interface entry point.
+
+    Parameters
+    ----------
+    arguments : argparse.ArgumentParser
+        Argument parser.
+    main_func : function
+        Main function.
+
+    """
+    cmd = load_args(arguments)
+    main_func(**vars(cmd))
+
+
+def maincli():
+    """Execute main client."""
+    cli(argument_parser, main)
+
+
+def main(input_pdbs, db):
+    """Main function."""
+    log.setLevel("DEBUG")
+
+    with open("uniprot.csv", "w") as fh:
+        for pdb in input_pdbs:
+            fasta_f = to_fasta(pdb, temp=True)
+            uniprot_id = run_blast(fasta_f.name, db)
+            Path(fasta_f.name).unlink()
+            log.info(f"pdb: {pdb} uniprot_id: {uniprot_id}")
+            fh.write(f"{pdb},{uniprot_id}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(maincli())

--- a/src/arctic3d/modules/sequence.py
+++ b/src/arctic3d/modules/sequence.py
@@ -1,3 +1,8 @@
+import tempfile
+
+from pdbtools.pdb_tofasta import pdb_to_fasta
+
+
 def load_seq(fasta_file):
     """
     Load sequence.
@@ -14,3 +19,32 @@ def load_seq(fasta_file):
 
     """
     pass
+
+
+def to_fasta(pdb_f, temp):
+    """
+    Convert PDB to Fasta.
+
+    Parameters
+    ----------
+    pdb_f : str
+        PDB filename.
+
+    Returns
+    -------
+    fasta_fh : str
+        Fasta sequence.
+
+    """
+    if temp:
+        fasta_fh = tempfile.NamedTemporaryFile(mode="w", suffix=".fasta", delete=False)
+    else:
+        fasta_fh = open(pdb_f.with_suffix(".fasta"), "w")
+
+    with open(pdb_f, "r") as inp_fh:
+        for line in pdb_to_fasta(inp_fh, multi=False):
+            fasta_fh.write(line)
+
+    fasta_fh.close()
+
+    return fasta_fh


### PR DESCRIPTION
This adds a new cli called `arctic3d-blast` which should help to identify the uniprotID of a list of PDB structures

```
$ arctic3d-blast `ls BM5-clean/HADDOCK-ready/*/*l_u.pdb BM5-clean/HADDOCK-ready/*/*r_u.pdb` --db ~/repos/arctic3d/db/swissprot
$ cat uniprot.csv
BM5-clean/HADDOCK-ready/1A2K/1A2K_l_u.pdb,P62825
BM5-clean/HADDOCK-ready/1A2K/1A2K_r_u.pdb,P61970
BM5-clean/HADDOCK-ready/1ACB/1ACB_l_u.pdb,P01051
BM5-clean/HADDOCK-ready/1ACB/1ACB_r_u.pdb,P00766
BM5-clean/HADDOCK-ready/1AHW/1AHW_l_u.pdb,P13726
BM5-clean/HADDOCK-ready/1AHW/1AHW_r_u.pdb,P0DOX7
BM5-clean/HADDOCK-ready/1AK4/1AK4_l_u.pdb,P05889
```