### PR TITLE
Fix `sphinx.builders.linkcheck` import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ In order to generate a detailed html documentation please execute these commands
 
 ```text
 pip install myst_parser
+pip install chardet
 conda install sphinx
 sphinx-build -E docs ./arctic3d-docs
 ```


### PR DESCRIPTION
I could not build the docs without this change because of the following error:
```
Could not import extension sphinx.builders.linkcheck (exception: cannot import name 'COMMON_SAFE_ASCII_CHARACTERS' from 'charset_normalizer.constant' 
```