### PR TITLE
added dummy test for cli

### DIFF
--- a/src/arctic3d/cli.py
+++ b/src/arctic3d/cli.py
@@ -289,7 +289,11 @@ def main(
     log.info(
         f"arctic3d run completed in {(time.time() - st_time):.2f} seconds."
     )
-    shutil.move(f"../{LOGNAME}", LOGNAME)
+
+    # move log file to output folder
+    exp_log_path = Path(f"../{LOGNAME}")
+    if exp_log_path.exists():
+        shutil.move(exp_log_path, LOGNAME)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+from arctic3d.cli import main
+import shutil
+from pathlib import Path
+import os
+
+
+def test_cli_empty():
+    """Test main cli with uniprot ID with no interfaces."""
+    target_uniprot = "P23804"
+    start_cwd = os.getcwd()
+    main(
+        target_uniprot,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    os.chdir(start_cwd)
+    exp_dir = Path(f"arctic3d-{target_uniprot}")
+    assert exp_dir.exists() is True
+    if exp_dir.exists():
+        shutil.rmtree(exp_dir)


### PR DESCRIPTION
Closes #82 by adding a simple, dummy test that tests the execution of the main CLI with a uniprot ID that has no interfaces.