### PR TITLE
Refactor pdb cif

### DIFF
--- a/src/arctic3d/cli.py
+++ b/src/arctic3d/cli.py
@@ -111,14 +111,6 @@ argument_parser.add_argument(
     default="average",
 )
 
-argument_parser.add_argument(
-    "--numbering",
-    help="what to renumber while extracting the best pdb files",
-    type=str,
-    default="pdb",
-    choices=["pdb", "resi"],
-)
-
 
 def load_args(arguments):
     """
@@ -174,7 +166,6 @@ def main(
     ligand,
     linkage_strategy,
     threshold,
-    numbering,
     log_level="DEBUG",
 ):
     """Main function."""
@@ -266,7 +257,6 @@ def main(
                 pdb_to_use=pdb_to_use,
                 chain_to_use=chain_to_use,
                 pdb_data=pdb_data_path,
-                numbering=numbering,
             )
 
         if pdb_f is None:

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -842,7 +842,6 @@ def get_best_pdb(
     pdb_f, cif_f, top_hit, filtered_interfaces = get_maxint_pdb(
         validated_pdbs_and_cifs,
         interface_residues,
-        uniprot_id,
     )
 
     if pdb_f is None or cif_f is None:

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -11,7 +11,6 @@ from pdbecif.mmcif_io import MMCIF2Dict
 from pdbtools.pdb_selchain import select_chain
 from pdbtools.pdb_tidy import tidy_pdbfile
 from pdbtools.pdb_selmodel import select_model
-from pdbtools.pdb_fromcif import convert_to_pdb
 
 
 from arctic3d.functions import make_request
@@ -382,15 +381,6 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 for new_line in pdb_lines:
                     wfile.write(new_line)
     return [out_pdb_fnames]
-
-
-def cif_to_pdb(cif_fname, out_pdb_name):
-    out_pdb_fname = Path(out_pdb_name)
-    with open(cif_fname, "r") as pdb_fh:
-        with open(out_pdb_fname, "w") as f:
-            for line in convert_to_pdb(pdb_fh):
-                f.write(line)
-    return out_pdb_fname
 
 
 def fetch_pdb_files(pdb_to_fetch, uniprot_id):

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -327,12 +327,14 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 if len(ats_dict["auth_asym_id"][residx]) == 1
                 else ats_dict["label_asym_id"][residx]
             )
+            model_id = int(ats_dict["pdbx_PDB_model_num"][residx])
             # check if we have to consider this line
             if (
                 atom_keyword == "ATOM"
                 and resid != "?"
                 and curr_uniprot_id == uniprot_id
                 and atom_symbol != "H"
+                and model_id == 1
             ):
                 pdb_fname = Path(f"{pdb_id}-{chain}.pdb")
                 if pdb_fname not in out_pdb_fnames:
@@ -403,7 +405,7 @@ def fetch_pdb_files(pdb_to_fetch, uniprot_id):
     Returns
     -------
     validated_pdbs : list
-        list of tuples (pdb_file, hit)
+        list of tuples (pdb_file, cif_file, hit)
     """
     validated_pdb_and_cifs = []
     valid_pdb_set = set()  # set of valid pdb IDs
@@ -667,14 +669,14 @@ def preprocess_pdb(pdb_fname, chain_id):
     tidy_pdb_f : Path
         preprocessed pdb file
     """
-    model_pdb_f = selmodel_pdb(pdb_fname)
-    atoms_pdb_f = keep_atoms(model_pdb_f)
-    chained_pdb_f = selchain_pdb(atoms_pdb_f, chain_id)
-    occ_pdb_f = occ_pdb(chained_pdb_f)
+    # model_pdb_f = selmodel_pdb(pdb_fname)
+    # atoms_pdb_f = keep_atoms(model_pdb_f)
+    # chained_pdb_f = selchain_pdb(atoms_pdb_f, chain_id)
+    occ_pdb_f = occ_pdb(pdb_fname)
     tidy_pdb_f = tidy_pdb(occ_pdb_f)
 
-    atoms_pdb_f.unlink()
-    chained_pdb_f.unlink()
+    # atoms_pdb_f.unlink()
+    # chained_pdb_f.unlink()
     occ_pdb_f.unlink()
 
     return tidy_pdb_f
@@ -742,7 +744,7 @@ def get_maxint_pdb(
                 pdb_f = tidy_pdb_f
                 cif_f = curr_cif_f
                 hit = curr_hit
-        # unlink pdb files
+        # unlink pdb and cif files
         unlink_files("pdb", to_exclude=[pdb_f])
         unlink_files("cif", to_exclude=[cif_f])
 

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -78,7 +78,6 @@ def _flush(register, option, others):
 
             # selected by option:
             else:
-                print(f"selected by option: {option}")
                 if option in altlocs:
                     # selects the option, that's it
                     lines_to_yield.extend(_remove_altloc(altlocs[option]))
@@ -277,7 +276,6 @@ def check_big_uni(ats_dict, uniprot_id):
         True if uniprot ID has residue IDs > 9999
     """
     len_sifts_mapping = len(ats_dict["auth_seq_id"])
-    print(f"len_sifts_mapping {len_sifts_mapping}")
     big_uni = False
     for residx in range(len_sifts_mapping):
         curr_uniprot_id = ats_dict["pdbx_sifts_xref_db_acc"][residx]

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -288,7 +288,7 @@ def check_big_uni(ats_dict, uniprot_id):
 
 def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
     """
-    Converts a cif file into a pdb file for each chain matchin the uniprot_id
+    Converts a cif file into a pdb file for each chain matching the uniprot_id
 
     Parameters
     ----------
@@ -315,6 +315,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
     else:
         # iterating over the atomsite_dict
         for residx in range(len_sifts_mapping):
+            # extracting key variables from the atom_site dict
             atom_keyword = ats_dict["group_PDB"][residx]
             resid = ats_dict["pdbx_sifts_xref_db_num"][residx]
             curr_uniprot_id = ats_dict["pdbx_sifts_xref_db_acc"][residx]
@@ -325,7 +326,8 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 else ats_dict["label_asym_id"][residx]
             )
             model_id = int(ats_dict["pdbx_PDB_model_num"][residx])
-            # check if we have to consider this line
+            # given the valuse of these variables, check if we have to
+            # consider this line
             if (
                 atom_keyword == "ATOM"
                 and resid != "?"
@@ -333,6 +335,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 and atom_symbol != "H"
                 and model_id == 1
             ):
+                # getting the correct pdb filename to write on
                 pdb_fname = Path(f"{pdb_id}-{chain}.pdb")
                 if pdb_fname not in out_pdb_fnames:
                     out_pdb_fnames.append(pdb_fname)
@@ -369,6 +372,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                     f"{x:>11}{y:>8}{z:>8}{occ:>6}{bfactor:>6}"
                     f"{os.linesep}"
                 )
+                # appending new line to the correct pdb file
                 if len(out_pdb_lines) <= atom_idx:
                     out_pdb_lines.append([new_line])
                 else:

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -329,7 +329,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 atom_keyword == "ATOM"
                 and resid != "?"
                 and curr_uniprot_id == uniprot_id
-                and atom_symbol != "H"
+                and atom_symbol not in  ["H", "D"]
                 and model_id == 1
             ):
                 # getting the correct pdb filename to write on

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -379,7 +379,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
             with open(pdb_fname, "w") as wfile:
                 for new_line in pdb_lines:
                     wfile.write(new_line)
-    return [out_pdb_fnames]
+    return out_pdb_fnames
 
 
 def fetch_pdb_files(pdb_to_fetch, uniprot_id):

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -14,10 +14,7 @@ from pdbtools.pdb_selmodel import select_model
 
 
 from arctic3d.functions import make_request
-from arctic3d.modules.interface_matrix import (
-    filter_interfaces,
-    format_interface_name,
-)
+from arctic3d.modules.interface_matrix import filter_interfaces
 
 log = logging.getLogger("arctic3d.log")
 
@@ -722,7 +719,7 @@ def get_maxint_pdb(
         max_nint = 0
         for curr_pdb, curr_cif_f, curr_hit in validated_pdbs:
             chain_id = curr_hit["chain_id"]
-            
+
             # preprocessing pdb file
             tidy_pdb_f = preprocess_pdb(curr_pdb, chain_id)
 

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -746,31 +746,6 @@ def get_maxint_pdb(
     return pdb_f, cif_f, hit, filtered_interfaces
 
 
-def filter_interfaces_cif(interface_residues, cif_resids):
-    """
-    Filter the interfaces according to the residues present in the cif file.
-
-    Parameters
-    ----------
-    interface_residues : dict
-        Dictionary of all the interfaces (each one with its uniprot ID as key)
-    cif_resids : list
-        List of residues present in the cif file
-    """
-    retained_interfaces = {}
-    for key in interface_residues.keys():
-        filtered_interface = [
-            el for el in interface_residues[key] if el in cif_resids
-        ]
-        coverage = len(filtered_interface) / len(interface_residues[key])
-        if coverage > 0.7:
-            # formatting the interface name to avoid spaces
-            formatted_key = format_interface_name(key)
-            retained_interfaces[formatted_key] = filtered_interface
-    log.debug(f"{len(retained_interfaces.keys())} retained_interfaces")
-    return retained_interfaces
-
-
 def filter_pdb_list(fetch_list, pdb_to_use=None, chain_to_use=None):
     """
     Filter the PDB fetch list.

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -349,11 +349,11 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                     else " "
                 )
                 resname = ats_dict["label_comp_id"][residx]
-                ins_code = (
-                    ats_dict["pdbx_PDB_ins_code"][residx]
-                    if ats_dict["pdbx_PDB_ins_code"][residx] != "?"
-                    else " "
-                )
+                # ins_code = (
+                #     ats_dict["pdbx_PDB_ins_code"][residx]
+                #     if ats_dict["pdbx_PDB_ins_code"][residx] != "?"
+                #     else " "
+                # )
                 # numbers
                 x = "{:.3f}".format(float(ats_dict["Cartn_x"][residx]))
                 y = "{:.3f}".format(float(ats_dict["Cartn_y"][residx]))
@@ -365,7 +365,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 # creating new line
                 new_line = (
                     f"{atom_keyword}  {atom_id:>5}  {atom_name:<3}{alt_id:<1}"
-                    f"{resname:<3} {chain}{resid:>4}{ins_code:<1}"
+                    f"{resname:<3} {chain}{resid:>4} "  # removed ins_code
                     f"{x:>11}{y:>8}{z:>8}{occ:>6}{bfactor:>6}"
                     f"{os.linesep}"
                 )

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -329,7 +329,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 atom_keyword == "ATOM"
                 and resid != "?"
                 and curr_uniprot_id == uniprot_id
-                and atom_symbol not in  ["H", "D"]
+                and atom_symbol not in ["H", "D"]
                 and model_id == 1
             ):
                 # getting the correct pdb filename to write on

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -693,7 +693,7 @@ def unlink_files(suffix="pdb", to_exclude=None):
 
 
 def get_maxint_pdb(
-    validated_pdbs, interface_residues, uniprot_id, numbering="pdb"
+    validated_pdbs, interface_residues
 ):
     """
     Get PDB ID that retains the most interfaces.
@@ -704,10 +704,17 @@ def get_maxint_pdb(
         List of (pdb_f, hit) tuples
     interface_residues : dict
         Dictionary of all the interfaces (each one with its uniprot ID as key)
-    uniprot_id : str
-        Uniprot ID
-    numbering : str
-        what to renumber? 'pdb' for pdb files, 'resi' for interface residues
+
+    Returns
+    -------
+    pdb_f : Path
+        Path to best PDB file.
+    cif_f : Path
+        Path to best CIF file.
+    hit : dict
+        Best hit.
+    filtered_interfaces : dict
+        Dictionary of filtered interfaces.
     """
     log.info("Selecting pdb retaining the most interfaces")
     cif_f, pdb_f, hit, filtered_interfaces = None, None, None, None
@@ -715,8 +722,8 @@ def get_maxint_pdb(
         max_nint = 0
         for curr_pdb, curr_cif_f, curr_hit in validated_pdbs:
             chain_id = curr_hit["chain_id"]
-
-            # refactor renumbering
+            
+            # preprocessing pdb file
             tidy_pdb_f = preprocess_pdb(curr_pdb, chain_id)
 
             try:
@@ -787,7 +794,6 @@ def get_best_pdb(
     pdb_to_use=None,
     chain_to_use=None,
     pdb_data=None,
-    numbering="pdb",
 ):
     """
     Get best PDB ID.
@@ -804,8 +810,6 @@ def get_best_pdb(
         Chain id to be used.
     pdb_data : Path or None
         pdb json file for offline mode.
-    numbering : str (default pdb)
-        what to renumber, either the pdb files or the interface residues
 
     Returns
     -------
@@ -844,7 +848,6 @@ def get_best_pdb(
         validated_pdbs_and_cifs,
         interface_residues,
         uniprot_id,
-        numbering=numbering,
     )
 
     if pdb_f is None or cif_f is None:

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -332,7 +332,7 @@ def convert_cif_to_pdbs(cif_fname, pdb_id, uniprot_id):
                 and atom_symbol != "H"
                 and model_id == 1
             ):
-                # getting the correct pdb filename to write on
+                # getting the correct pdb filename to write on
                 pdb_fname = Path(f"{pdb_id}-{chain}.pdb")
                 if pdb_fname not in out_pdb_fnames:
                     out_pdb_fnames.append(pdb_fname)
@@ -689,9 +689,7 @@ def unlink_files(suffix="pdb", to_exclude=None):
             fpath.unlink()
 
 
-def get_maxint_pdb(
-    validated_pdbs, interface_residues
-):
+def get_maxint_pdb(validated_pdbs, interface_residues):
     """
     Get PDB ID that retains the most interfaces.
 

--- a/src/arctic3d/modules/pdb.py
+++ b/src/arctic3d/modules/pdb.py
@@ -658,14 +658,9 @@ def preprocess_pdb(pdb_fname, chain_id):
     tidy_pdb_f : Path
         preprocessed pdb file
     """
-    # model_pdb_f = selmodel_pdb(pdb_fname)
-    # atoms_pdb_f = keep_atoms(model_pdb_f)
-    # chained_pdb_f = selchain_pdb(atoms_pdb_f, chain_id)
     occ_pdb_f = occ_pdb(pdb_fname)
     tidy_pdb_f = tidy_pdb(occ_pdb_f)
 
-    # atoms_pdb_f.unlink()
-    # chained_pdb_f.unlink()
     occ_pdb_f.unlink()
 
     return tidy_pdb_f

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,6 @@ def test_cli_empty():
         ligand=None,
         linkage_strategy=None,
         threshold=None,
-        numbering=None,
     )
     os.chdir(start_cwd)
     exp_dir = Path(f"arctic3d-{target_uniprot}")

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -12,6 +12,7 @@ from arctic3d.modules.pdb import (
     selmodel_pdb,
     tidy_pdb,
     validate_api_hit,
+    convert_cif_to_pdbs,
 )
 
 from . import golden_data
@@ -263,3 +264,20 @@ def test_pdb_data(inp_pdb_data):
     assert filtered_interfaces == orig_interfaces
     pdb.unlink()
     cif.unlink()
+
+
+def test_convert_cif_to_pdbs(inp_cif_3psg):
+    """Test convert_cif_to_pdbs."""
+    obs_out_pdb_fnames = convert_cif_to_pdbs(inp_cif_3psg, "3psg", "P00791")
+    print(f"obs_out_pdb_fnames {obs_out_pdb_fnames}")
+    exp_out_pdb_fnames = [Path("3psg-A.pdb")]
+    assert exp_out_pdb_fnames == obs_out_pdb_fnames
+    # inspect the pdb file
+    obs_pdb_lines = obs_out_pdb_fnames[0].read_text().splitlines()
+    # checking first and last lines
+    exp_pdb_lines = [
+        "ATOM      1  N   LEU A  16      57.364  -9.595   2.554  1.00 21.58",
+        "ATOM   2692  CB  ALA A 385      39.553 -10.495   1.923  1.00 22.44",
+    ]
+    assert obs_pdb_lines[0] == exp_pdb_lines[0]
+    assert obs_pdb_lines[-1] == exp_pdb_lines[-1]

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -216,7 +216,7 @@ def test_get_maxint_pdb_empty():
     """Test get_maxint_pdb with empty output."""
     empty_validated_pdbs = []
     pdb_f, cif_f, top_hit, filtered_interfaces = get_maxint_pdb(
-        empty_validated_pdbs, {}, uniprot_id=None
+        empty_validated_pdbs, {}
     )
     assert pdb_f is None
     assert cif_f is None
@@ -227,9 +227,8 @@ def test_get_maxint_pdb_empty():
 def test_get_maxint_pdb(good_hits, example_interfaces):
     """Test get_maxint_pdb with implicit pdb numbering."""
     validated_pdbs = validate_api_hit(good_hits, "P00760")
-    print(f"validated_pdbs {validated_pdbs}")
     pdb_f, cif_f, top_hit, filtered_interfaces = get_maxint_pdb(
-        validated_pdbs, example_interfaces, "P00760"
+        validated_pdbs, example_interfaces
     )
     assert pdb_f.name == "4xoj-A-occ-tidy.pdb"
     assert cif_f.name == "4xoj_updated.cif"


### PR DESCRIPTION
Closes #285 by downloading an mmcif file and splitting it into all the chains that contain the desired uniprot ID.

This allows to eliminate three of the following pdbtools-dependent preprocessing steps, namely chain selection, model selection and heteroatoms removal.