### PR TITLE
fixed help message

### DIFF
--- a/src/arctic3d/cli.py
+++ b/src/arctic3d/cli.py
@@ -123,7 +123,7 @@ argument_parser.add_argument(
 
 argument_parser.add_argument(
     "--int_cov_cutoff",
-    help="Interface coverage cutoff (%)",
+    help="Interface coverage cutoff (%%)",
     type=float,
     required=False,
     default=0.7,


### PR DESCRIPTION
Closes #366. The problem arose because of PR #342 , whose help message didn't contain the necessary escape character for %