### PR TITLE
Tweak `trunk` linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,6 @@ jobs:
 
       - run: poetry install --no-interaction --no-root
 
-      - uses: trunk-io/trunk-action@v1
-        with:
-          check-mode: all
-
       - name: Test
         run: |
           poetry run pytest --cov=./ --cov-report=xml -v

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,6 +2,8 @@
 *logs
 *actions
 *notifications
+*tools
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/configs/.hadolint.yaml
+++ b/.trunk/configs/.hadolint.yaml
@@ -1,0 +1,4 @@
+# Following source doesn't work in most setups
+ignored:
+  - SC1090
+  - SC1091

--- a/.trunk/configs/.isort.cfg
+++ b/.trunk/configs/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,10 +1,2 @@
-# Autoformatter friendly markdownlint config (all formatting rules disabled)
-default: true
-blank_lines: false
-bullet: false
-html: false
-indentation: false
-line_length: false
-spaces: false
-url: false
-whitespace: false
+# Prettier friendly markdownlint config (all formatting rules disabled)
+extends: markdownlint/style/prettier

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,7 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,0 +1,5 @@
+# Generic, formatter-friendly config.
+select = ["B", "D3", "E", "F"]
+
+# Never enforce `E501` (line length violations). This should be handled by formatters.
+ignore = ["E501"]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,31 +1,42 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.4.1
+  version: 1.21.0
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.9
+      ref: v1.4.5
       uri: https://github.com/trunk-io/plugins
-lint:
-  enabled:
-    - taplo@0.7.0
-    - black@23.1.0
-    - gitleaks@8.15.3
-    - shellcheck@0.9.0
-    - git-diff-check
-    - oxipng@8.0.0
-    - prettier@2.8.3
-    - flake8@6.0.0
-    - shfmt@3.5.0
-    - actionlint@1.6.23
-    - markdownlint@0.33.0
-  disabled:
-    - isort
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.18.3
+    - go@1.21.0
     - node@18.12.1
     - python@3.10.8
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - actionlint@1.6.27
+    - bandit@1.7.8
+    - black@24.4.0
+    - checkov@3.2.71
+    - git-diff-check
+    - hadolint@2.12.0
+    - isort@5.13.2
+    - markdownlint@0.39.0
+    - osv-scanner@1.7.2
+    - oxipng@9.0.0
+    - prettier@3.2.5
+    - ruff@0.4.0
+    - shellcheck@0.10.0
+    - shfmt@3.6.0
+    - taplo@0.8.1
+    - terrascan@1.19.1
+    - trivy@0.50.1
+    - trufflehog@3.71.0
+    - yamllint@1.35.1
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
This PR upgrades the trunk version used by the repo and removes the `trunk-check` action, since they should be being managed by the `pre-commit` hooks.