### PR TITLE
add `--biological-clustering` option

### DIFF
--- a/src/arctic3d/cli.py
+++ b/src/arctic3d/cli.py
@@ -131,6 +131,17 @@ argument_parser.add_argument(
     default=0.7,
 )
 
+argument_parser.add_argument(
+    "--biological_clustering",
+    help="Perform biological clustering of partners. Can specify multiple types: "
+    "'location' clusters by subcellular location, "
+    "'function' clusters by protein function, "
+    "'process' clusters by biological process",
+    nargs="*",
+    choices=["location", "function", "process"],
+    default=[],
+)
+
 
 def load_args(arguments):
     """
@@ -188,6 +199,7 @@ def main(
     threshold,
     min_clust_size,
     int_cov_cutoff,
+    biological_clustering,
     log_level="DEBUG",
 ):
     """Main function."""
@@ -333,6 +345,56 @@ def main(
     # check if there's at least one interface
     if Path("clustered_interfaces.out").is_file() is False:
         return 255
+
+    # run biological clustering if requested
+    if biological_clustering and interface_residues:
+        from arctic3d.cli_localise import main as localise_main
+
+        # map user-friendly names to quickgo keys and directory names
+        # to match webserver behavior
+        clustering_config = {
+            "location": {
+                "quickgo": "C",  # QuickGO subcellular location
+                "dir": "arctic3d-localise-subcellular",
+            },
+            "function": {
+                "quickgo": "F",  # QuickGO protein function
+                "dir": "arctic3d-localise-proteinfunction",
+            },
+            "process": {
+                "quickgo": "P",  # QuickGO biological process
+                "dir": "arctic3d-localise-biologicalprocess",
+            },
+        }
+
+        for clustering_type in biological_clustering:
+            config = clustering_config[clustering_type]
+            quickgo_param = config["quickgo"]
+            localise_run_dir = config["dir"]
+
+            log.info(
+                f"Running biological clustering by {clustering_type}..."
+            )
+
+            try:
+                localise_main(
+                    input_arg="clustered_interfaces.out",
+                    run_dir=localise_run_dir,
+                    out_partner=out_partner,
+                    quickgo=quickgo_param,
+                    weight="no",
+                    format="png",
+                    scale=4.0,
+                    log_level=log_level,
+                )
+                log.info(
+                    f"Biological clustering by {clustering_type} completed. "
+                    f"Results in {localise_run_dir}/"
+                )
+            except Exception as e:
+                log.warning(
+                    f"Biological clustering by {clustering_type} failed: {e}"
+                )
 
     return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -29,6 +30,7 @@ def test_cli_empty():
         threshold=None,
         int_cov_cutoff=None,
         min_clust_size=None,
+        biological_clustering=[],
     )
     # assert exit code
     assert exit_code == 255
@@ -68,6 +70,7 @@ def test_cli_full():
         threshold=None,
         min_clust_size=1,
         int_cov_cutoff=0.7,
+        biological_clustering=[],
     )
     assert exit_code == 0
     os.chdir(start_cwd)
@@ -81,5 +84,134 @@ def test_cli_full():
     exp_content = f"Cluster 1 -> Q9L5A4-3wqb-A{os.linesep}"
     assert exp_content == obs_content
     # remove folder
+    if exp_dir.exists():
+        shutil.rmtree(exp_dir)
+
+
+@pytest.mark.integration
+def test_biological_clustering_integration():
+    """Integration test for biological_clustering with location option."""
+    target_uniprot = "W5JXD7"
+    exp_dir = Path(f"arctic3d-{target_uniprot}")
+    localise_dir = Path("arctic3d-localise-subcellular")
+
+    # Clean up if exists
+    if exp_dir.exists():
+        shutil.rmtree(exp_dir)
+    if localise_dir.exists():
+        shutil.rmtree(localise_dir)
+
+    start_cwd = os.getcwd()
+    exit_code = main(
+        input_arg=target_uniprot,
+        db=None,
+        interface_file=None,
+        out_partner=None,
+        out_pdb=None,
+        pdb_to_use="3wqb",
+        chain_to_use=None,
+        run_dir=None,
+        interface_data=None,
+        pdb_data=None,
+        full=None,
+        ligand="no",
+        linkage_strategy=None,
+        threshold=None,
+        min_clust_size=1,
+        int_cov_cutoff=0.7,
+        biological_clustering=["location"],
+    )
+
+    # Verify main clustering succeeded
+    assert exit_code == 0
+
+    # Change back to original directory before checking files
+    os.chdir(start_cwd)
+
+    # Verify main clustering directory was created
+    assert exp_dir.exists()
+    assert Path(exp_dir, "clustered_interfaces.out").exists()
+
+    # Verify biological clustering directory was created
+    # (localise creates directory in the main arctic3d dir)
+    localise_dir_full = Path(exp_dir, "arctic3d-localise-subcellular")
+    if localise_dir_full.exists():
+        assert Path(localise_dir_full, "arctic3d-localise.log").exists()
+    elif localise_dir.exists():
+        # Or it might be in the working directory
+        assert Path(localise_dir, "arctic3d-localise.log").exists()
+
+    # Cleanup
+    if exp_dir.exists():
+        shutil.rmtree(exp_dir)
+    if localise_dir.exists():
+        shutil.rmtree(localise_dir)
+
+
+def test_biological_clustering_config():
+    """Unit test to verify biological clustering configuration is correct."""
+    # Test the configuration mapping matches webserver
+    clustering_config = {
+        "location": {
+            "quickgo": "C",
+            "dir": "arctic3d-localise-subcellular",
+        },
+        "function": {
+            "quickgo": "F",
+            "dir": "arctic3d-localise-proteinfunction",
+        },
+        "process": {
+            "quickgo": "P",
+            "dir": "arctic3d-localise-biologicalprocess",
+        },
+    }
+
+    # Verify all config values are correct
+    assert clustering_config["location"]["quickgo"] == "C"
+    assert clustering_config["location"]["dir"] == "arctic3d-localise-subcellular"
+
+    assert clustering_config["function"]["quickgo"] == "F"
+    assert clustering_config["function"]["dir"] == "arctic3d-localise-proteinfunction"
+
+    assert clustering_config["process"]["quickgo"] == "P"
+    assert clustering_config["process"]["dir"] == "arctic3d-localise-biologicalprocess"
+
+
+@pytest.mark.integration
+def test_biological_clustering_not_called_when_no_interfaces(monkeypatch):
+    """Test that biological_clustering is not executed when there are no interfaces."""
+    # Mock localise_main to track if it's called
+    mock_localise = MagicMock()
+    monkeypatch.setattr("arctic3d.cli_localise.main", mock_localise)
+
+    target_uniprot = "P23804"  # This uniprot has no interfaces
+    start_cwd = os.getcwd()
+    exit_code = main(
+        input_arg=target_uniprot,
+        db=None,
+        interface_file=None,
+        out_partner=None,
+        out_pdb=None,
+        pdb_to_use=None,
+        chain_to_use=None,
+        run_dir=None,
+        interface_data=None,
+        pdb_data=None,
+        full=None,
+        ligand=None,
+        linkage_strategy=None,
+        threshold=None,
+        int_cov_cutoff=None,
+        min_clust_size=None,
+        biological_clustering=["location", "function"],
+    )
+
+    # Verify localise was NOT called since there are no interfaces
+    mock_localise.assert_not_called()
+    assert exit_code == 255
+
+    # Cleanup
+    os.chdir(start_cwd)
+    exp_dir = Path(f"arctic3d-{target_uniprot}")
     if exp_dir.exists():
         shutil.rmtree(exp_dir)


### PR DESCRIPTION
The web service offers the users options that are not enabled here, these are to cluster by subcellular location, biological process and function.

This is achieved (in the web service) by running multiple `arctic3d-localise` with different parameters.

This PR here adds a new option that wraps this execution and should match the same functionality as seen in the web version.